### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/deploy-to-huggingface.yml
+++ b/.github/workflows/deploy-to-huggingface.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -60,7 +60,7 @@ jobs:
           uvx --refresh https://github.com/drbh/uvnote.git build benches --strict
 
       - name: Upload Linux site artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: site-linux
           path: site/
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -98,7 +98,7 @@ jobs:
           uvx --refresh https://github.com/drbh/uvnote.git build benches --strict
 
       - name: Upload macOS site artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: site-darwin
           path: site/
@@ -111,13 +111,13 @@ jobs:
 
     steps:
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: site-linux
           path: site/
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: site-darwin
           path: site/


### PR DESCRIPTION
## Summary
This PR upgrades GitHub Actions to their latest versions for Node.js 24 compatibility and security updates.

## Changes

| Action | Old Version(s) | New Version | Files |
|--------|---------------|-------------|-------|
| actions/checkout | v4 | v6 | deploy-to-huggingface.yml |
| actions/download-artifact | v4 | v7 | deploy-to-huggingface.yml |
| actions/upload-artifact | v4 | v6 | deploy-to-huggingface.yml |

## Why these changes?
- Keeps actions up to date with latest stable releases
- Updated actions include security fixes and new features

## Testing
These changes only update action versions and don't modify workflow logic.
